### PR TITLE
feat: add response transform and handle different response types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export default class Holen extends React.Component {
     const updateState = (error, response) => {
       this.setState(
         {
-          data: response && response.data ? response.data : undefined,
+          data: response && response.data ? this.props.transformResponse(response.data) : undefined,
           error,
           fetching: false,
           response
@@ -67,8 +67,7 @@ export default class Holen extends React.Component {
           return
         }
 
-        return res
-          .json()
+        return res[this.props.type]()
           .then(data => {
             res.data = data
             return res
@@ -114,10 +113,14 @@ Holen.propTypes = {
   lazy: PropTypes.bool,
   method: PropTypes.oneOf(['get', 'post', 'put', 'delete', 'GET', 'POST', 'PUT', 'DELETE']),
   onResponse: PropTypes.func,
-  url: PropTypes.string.isRequired
+  url: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(['json', 'text', 'blob']),
+  transformResponse: PropTypes.func
 }
 
 Holen.defaultProps = {
   method: 'get',
-  onResponse: () => {}
+  type: 'json',
+  onResponse: () => {},
+  transformResponse: data => data
 }


### PR DESCRIPTION
This adds 2 features:

* handle different response types
* allow to do some transformation to the response

Usage:

```jsx
<Holen
      url='https://jsonplaceholder.typicode.com/todos'
      type='json'
      transformResponse={data => {
        return data.map(e => Object.assign(e, {holen: true}))
      }}
        >
      {({data}) => <pre>{JSON.stringify(data, null, 2)}</pre>}
    </Holen>
```

I see unfetch provides a `res.xml()` method, but fetch does not (ping @developit)
https://developer.mozilla.org/en-US/docs/Web/API/Response

That's the reason I only allowed `json`, `text` and `blob` as response types.

Still missing tests and docs
