### PR TITLE
Update to isomorphic-unfetch@^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "release": "npm run test && npm run build && npm version patch && npm publish && git push --tags"
   },
   "dependencies": {
-    "isomorphic-unfetch": "^1.0.0"
+    "isomorphic-unfetch": "^2.0.0"
   },
   "peerDependencies": {
     "react": ">=14"


### PR DESCRIPTION
This is to fix ESM issue with Webpack 2 and other module bundler that support ES modules natively

BTW, I'm not sure why but when Holen import `isomorphic-unfetch` it messes with my native fetch

