### PR TITLE
Added 'PATCH' to allowed request method values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,10 +113,12 @@ Holen.propTypes = {
     'get',
     'post',
     'put',
+    'patch',
     'delete',
     'GET',
     'POST',
     'PUT',
+    'PATCH',
     'DELETE'
   ]),
   onResponse: PropTypes.func,


### PR DESCRIPTION
Related to https://github.com/tkh44/holen/issues/9.
Added `PATCH` and `patch` as allowed values in the propTypes definition.
I couldn't see any tests that were impacted by doing this.
