### PR TITLE
Restrict credentials to valid values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ export default class Holen extends React.Component {
 Holen.propTypes = {
   body: PropTypes.any,
   children: PropTypes.func,
-  credentials: PropTypes.string,
+  credentials: PropTypes.oneOf(['omit', 'same-origin', 'include']),
   headers: PropTypes.object,
   lazy: PropTypes.bool,
   method: PropTypes.oneOf([


### PR DESCRIPTION
Source: https://fetch.spec.whatwg.org/#requests

This PR validates the options passed into `credentials`. From the spec:

> A request has an associated credentials mode, which is "omit", "same-origin", or "include". Unless stated otherwise, it is "omit".